### PR TITLE
Consider using a different section prefix than '$'

### DIFF
--- a/CSS Guidelines.md
+++ b/CSS Guidelines.md
@@ -5,7 +5,11 @@
 
 ## CSS documents
 
-We maintain a table of contents at the top of each CSS file which maps to sections in the document. Each section is prefixed with a `$` symbol which means that doing a find for `$[section name]` will only yield results that are sections.
+We maintain a table of contents at the top of each CSS file which maps to sections in the document. Each section is prefixed with a `=` character which means that doing a find for `=[section name]` will only yield results that are sections.
+
+**Read:**
+
+- [stopdesign.com/archive/2005/05/03/css-tip-flags.html](http://stopdesign.com/archive/2005/05/03/css-tip-flags.html)
 
 ### Syntax and formatting
 

--- a/CSS Guidelines.md
+++ b/CSS Guidelines.md
@@ -7,6 +7,12 @@
 
 We maintain a table of contents at the top of each CSS file which maps to sections in the document. Each section is prefixed with a `=` character which means that doing a find for `=[section name]` will only yield results that are sections.
 
+**Example:**
+
+	/*
+		=NAVIGATION
+	--------------------------------------- */
+
 **Read:**
 
 - [stopdesign.com/archive/2005/05/03/css-tip-flags.html](http://stopdesign.com/archive/2005/05/03/css-tip-flags.html)


### PR DESCRIPTION
It's clever to differentiate section titles with a prefix, but perhaps `$` isn't ideal – Sass uses it as variable name prefix. Conflicts may occur, that is.

Doug Bowman proposed using the equal sign (`=`) back in 2005 (http://stopdesign.com/archive/2005/05/03/css-tip-flags.html), and it works very well.

Other than that; great job!
